### PR TITLE
Workaround the deadlock issue hit by WMCO provisioning

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -267,11 +267,14 @@ func (r *Reconciler) setProviderID(vmUUID *string) error {
 		klog.Infof("%s: ProviderID set at machine.spec: %s", r.machine.Name, providerID)
 	}
 
+	if r.machine.Status.NodeRef == nil {
+		klog.Infof("%s: the Machine node is not ready yet.", r.machine.Name)
+		return nil
+	}
+
 	// update the corresponding node.Spec.ProviderID
 	var nodeName string
-	if r.machine.Status.NodeRef != nil {
-		nodeName = r.machine.Status.NodeRef.Name
-	}
+	nodeName = r.machine.Status.NodeRef.Name
 	if len(nodeName) == 0 {
 		nodeName = r.machine.Name
 	}


### PR DESCRIPTION
Workaround the deadlock issue hit by WMCO provisioning, when the Machine node not ready when updating the Machine.